### PR TITLE
[TIMOB-7970] Remove offending ICU calls

### DIFF
--- a/TiCore/TiCore.xcodeproj/project.pbxproj
+++ b/TiCore/TiCore.xcodeproj/project.pbxproj
@@ -3176,6 +3176,7 @@
 				DEAD_CODE_STRIPPING = "$(DEAD_CODE_STRIPPING_debug)";
 				DEBUG_DEFINES = "$(DEBUG_DEFINES_debug)";
 				GCC_OPTIMIZATION_LEVEL = "$(GCC_OPTIMIZATION_LEVEL_debug)";
+				SDKROOT = iphoneos;
 				STRIP_INSTALLED_PRODUCT = "$(STRIP_INSTALLED_PRODUCT_debug)";
 			};
 			name = Debug;
@@ -3184,6 +3185,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1C9051440BA9E8A70081E9D0 /* DebugRelease.xcconfig */;
 			buildSettings = {
+				SDKROOT = iphoneos;
 				STRIP_INSTALLED_PRODUCT = NO;
 			};
 			name = Release;
@@ -3192,6 +3194,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1C9051450BA9E8A70081E9D0 /* Base.xcconfig */;
 			buildSettings = {
+				SDKROOT = iphoneos;
 			};
 			name = Production;
 		};
@@ -3220,6 +3223,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1C9051440BA9E8A70081E9D0 /* DebugRelease.xcconfig */;
 			buildSettings = {
+				SDKROOT = iphoneos;
 				STRIP_INSTALLED_PRODUCT = NO;
 			};
 			name = Profiling;

--- a/TiCore/wtf/unicode/icu/CollatorICU.cpp
+++ b/TiCore/wtf/unicode/icu/CollatorICU.cpp
@@ -122,20 +122,7 @@ Collator::Result Collator::collate(const UChar* lhs, size_t lhsLength, const UCh
         locale = CFLocaleCopyCurrent();
     }
     
-    // CFStringCreateWithCharacters does not accept -1; we have to determine the terminator position ourselves.
-    if (lhsLength == (size_t)(-1)) {
-        lhsLength = 0;
-        while (*(lhs++) != 0x0000) {
-            lhsLength++;
-        }
-    }
-    if (rhsLength == (size_t)(-1)) {
-        rhsLength = 0;
-        while (*(rhs++) != 0x0000) {
-            rhsLength++;
-        }
-    }
-    
+    // We assume that lhsLength/rhsLength != -1, which is reasonable based on the source.
     
     RetainPtr<CFStringRef> lhsRef = CFStringCreateWithCharacters(NULL, (const UniChar*)lhs, lhsLength);
     RetainPtr<CFStringRef> rhsRef = CFStringCreateWithCharacters(NULL, (const UniChar*)rhs, rhsLength);

--- a/fixup.py
+++ b/fixup.py
@@ -6,7 +6,7 @@
 # naming conventions, etc so as not to conflict with an
 # existing install of KJS
 #
-import os, shutil, sys, re
+import os, shutil, sys, re, datetime
 
 if len(sys.argv) > 1:
 	root_dir = sys.argv[1]
@@ -72,7 +72,7 @@ copyright_ext = (
 
 #['jsAPIValueWrapper','TiAPIValueWrapper'],
 
-COPYRIGHT_NOW = date.today().strftime('%Y')
+COPYRIGHT_NOW = datetime.date.today().strftime('%Y')
 COPYRIGHT = """/**
  * Appcelerator Titanium License
  * This source code and all modifications done by Appcelerator


### PR DESCRIPTION
Apple validation was indicating that TiCore was calling out to some "private" methods inside the ICU library. This fix interfaces with them in the approved manner through CFLocale and CFString.

As a bonus there were some fixes made to the fixup script and building the XCode project without buildit.
