### PR TITLE
[TIMOB-18096] iOS: Proxies not being released

### DIFF
--- a/JavaScriptCore/API/TiBase.cpp
+++ b/JavaScriptCore/API/TiBase.cpp
@@ -114,9 +114,8 @@ void TiGarbageCollect(TiContextRef ctx)
         return;
 
     ExecState* exec = toJS(ctx);
-    APIEntryShim entryShim(exec, false);
-
-    exec->vm().heap.reportAbandonedObjectGraph();
+    APIEntryShim entryShim(exec);
+    exec->vm().heap.collectAllGarbage();
 }
 
 void JSReportExtraMemoryCost(TiContextRef ctx, size_t size)


### PR DESCRIPTION
TiGarbageCollect now collects all orphans so we van respond to memory pressures outside the JSCore VM
Fixes [TIMOB-18096](https://jira.appcelerator.org/browse/TIMOB-18096)
