### PR TITLE
Add xcpretty -c to reduce the verbosity of the build log files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,38 +9,6 @@ before_install:
 install:
 
 script:
- # Build WTF
- - rm -rf Build
- - rm -rf WTF/build
- - mkdir Build
- - set -o pipefail && xcodebuild -project WTF/WTF.xcodeproj -sdk iphonesimulator -configuration "Release" -target WTF clean | xcpretty -c
- - set -o pipefail && xcodebuild -project WTF/WTF.xcodeproj -sdk iphoneos -configuration "Release" -target WTF clean | xcpretty -c
- - set -o pipefail && xcodebuild -project WTF/WTF.xcodeproj -sdk iphonesimulator -configuration "Release" -target WTF | xcpretty -c
- - set -o pipefail && xcodebuild -project WTF/WTF.xcodeproj -sdk iphoneos -configuration "Release" -target WTF | xcpretty -c
- - lipo WTF/build/Release-iphonesimulator/libWTF.a WTF/build/Release-iphoneos/libWTF.a -create -output Build/libWTF.a
- - xcrun -sdk iphoneos lipo -info Build/libWTF.a 
-
- - mkdir Build/PRIVATE_HEADERS
- - cp -R WTF/build/Release-iphoneos/usr/local/include/ Build/PRIVATE_HEADERS
-
- - rm -rf WTF/build
-
- # Build TiJSCore
- - rm -rf JavaScriptCore/build
- - set -o pipefail && xcodebuild -project JavaScriptCore/JavaScriptCore.xcodeproj -sdk iphonesimulator -configuration "Release" -target JavaScriptCore clean | xcpretty -c
- - set -o pipefail && xcodebuild -project JavaScriptCore/JavaScriptCore.xcodeproj -sdk iphoneos -configuration "Release" -target JavaScriptCore clean | xcpretty -c
- - set -o pipefail && xcodebuild -project JavaScriptCore/JavaScriptCore.xcodeproj -sdk iphonesimulator -configuration "Release" -target JavaScriptCore | xcpretty -c
- - set -o pipefail && xcodebuild -project JavaScriptCore/JavaScriptCore.xcodeproj -sdk iphoneos -configuration "Release" -target JavaScriptCore | xcpretty -c
- - lipo JavaScriptCore/build/Release-iphonesimulator/libJavaScriptCore.a JavaScriptCore/build/Release-iphoneos/libJavaScriptCore.a -create -output Build/libTiCore.a
- - xcrun -sdk iphoneos lipo -info Build/libTiCore.a 
-
- - mkdir Build/PUBLIC_HEADERS
- - cp -R JavaScriptCore/build/Release-iphoneos/usr/local/include/ Build/PUBLIC_HEADERS
- - cp -R JavaScriptCore/build/Release-iphoneos/PRIVATE_HEADERS/ Build/PRIVATE_HEADERS
-
- - rm -rf JavaScriptCore/build
-
- - ls -la
- - ls -la Build/
+ - ./build.sh
 
 after_success:

--- a/build.sh
+++ b/build.sh
@@ -43,8 +43,8 @@ for project_name in ${project_name_list}; do
             fi
 
             log_file="${build_dir}/build_output-${project_name}-${sdk}-${arch}.txt"
-            echo_and_eval "(time ${xcodebuild} clean        ) | tee    ${log_file}"
-            echo_and_eval "(time ${xcodebuild} -arch ${arch}) | tee -a ${log_file}"
+            echo_and_eval "(time ${xcodebuild} clean        ) | tee    ${log_file} | xcpretty -c"
+            echo_and_eval "(time ${xcodebuild} -arch ${arch}) | tee -a ${log_file} | xcpretty -c"
             
             library_name1="lib${project_name}.a"
             library_path1="${project_build_dir}/${library_name1}"

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,9 @@ declare -r universal_library_path="${build_dir}/libTiCore.a"
 declare -r private_header_dir="${build_dir}/PRIVATE_HEADERS"
 declare -r public_header_dir="${build_dir}/PUBLIC_HEADERS/JavaScriptCore"
 
+type -a xcpretty
+declare -r xcpretty_installed=$?
+
 function echo_and_eval {
     local -r cmd="${1:?}"
     echo "${cmd}" && eval "${cmd}"
@@ -43,8 +46,17 @@ for project_name in ${project_name_list}; do
             fi
 
             log_file="${build_dir}/build_output-${project_name}-${sdk}-${arch}.txt"
-            echo_and_eval "(time ${xcodebuild} clean        ) | tee    ${log_file} | xcpretty -c"
-            echo_and_eval "(time ${xcodebuild} -arch ${arch}) | tee -a ${log_file} | xcpretty -c"
+						cmd="(time ${xcodebuild} clean        ) | tee    ${log_file}"
+						if [ ${xcpretty_installed} -eq 0 ]; then
+								cmd+=" | xcpretty -c"
+						fi
+
+						cmd="(time ${xcodebuild} -arch ${arch}) | tee -a ${log_file}"
+						if [ ${xcpretty_installed} -eq 0 ]; then
+								cmd+=" | xcpretty -c"
+						fi
+
+            echo_and_eval "${cmd}"
             
             library_name1="lib${project_name}.a"
             library_path1="${project_build_dir}/${library_name1}"


### PR DESCRIPTION
This PR adds `xcpretty -c` to reduce the verbosity of the build log files to work within the constraints of Travis CI.

To test, simply make sure that Travis CI is green.
