### PR TITLE
Arm64 align

### DIFF
--- a/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -538,10 +538,18 @@ TiValue CLoop::execute(CallFrame* callFrame, Opcode entryOpcode, bool isInitiali
 #if CPU(ARM_THUMB2)
 #define OFFLINE_ASM_GLOBAL_LABEL(label)          \
     ".text\n"                                    \
+    ".align 4\n"                                 \
     ".globl " SYMBOL_STRING(label) "\n"          \
     HIDE_SYMBOL(label) "\n"                      \
     ".thumb\n"                                   \
     ".thumb_func " THUMB_FUNC_PARAM(label) "\n"  \
+    SYMBOL_STRING(label) ":\n"
+#elif CPU(ARM64)
+    #define OFFLINE_ASM_GLOBAL_LABEL(label)         \
+    ".text\n"                                   \
+    ".align 4\n"                                \
+    ".globl " SYMBOL_STRING(label) "\n"         \
+    HIDE_SYMBOL(label) "\n"                     \
     SYMBOL_STRING(label) ":\n"
 #else
 #define OFFLINE_ASM_GLOBAL_LABEL(label)         \

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ To build first run the WTF script followed by the TiCore script.
 
 The built library will be in the Build Folder (generated) along with public and private headers from the WTF and JavaScriptCore projects (needed for Debugger/Profiler/Titanium)
 
-We are only generating i386, armv7 and arm64 slices in the static library (no armv7s and no x86_64)
+We are only generating i386, x86_64, armv7 and arm64 slices in the static library (no armv7s)

--- a/WTF/wtf/FastMalloc.cpp
+++ b/WTF/wtf/FastMalloc.cpp
@@ -98,6 +98,7 @@
 #include <wtf/StdLibExtras.h>
 
 #if OS(DARWIN)
+#include <mach/mach_init.h>
 #include <malloc/malloc.h>
 #endif
 
@@ -636,18 +637,35 @@ static ALWAYS_INLINE uint32_t freedObjectEndPoison()
 // Configuration
 //-------------------------------------------------------------------
 
+//// Not all possible combinations of the following parameters make
+//// sense.  In particular, if kMaxSize increases, you may have to
+//// increase kNumClasses as well.
+//#define K_PAGE_SHIFT 12
+//#define K_NUM_CLASSES 68
+//static const size_t kPageShift  = K_PAGE_SHIFT;
+//static const size_t kPageSize   = 1 << kPageShift;
+//static const size_t kMaxSize    = 32u * 1024;
+//static const size_t kAlignShift = 3;
+//static const size_t kAlignment  = 1 << kAlignShift;
+//static const size_t kNumClasses = K_NUM_CLASSES;
+
+// Type that can hold the length of a run of pages
+typedef uintptr_t Length;
+
 // Not all possible combinations of the following parameters make
 // sense.  In particular, if kMaxSize increases, you may have to
 // increase kNumClasses as well.
-#define K_PAGE_SHIFT 12
-#define K_NUM_CLASSES 68
-static const size_t kPageShift  = K_PAGE_SHIFT;
-static const size_t kPageSize   = 1 << kPageShift;
+#define K_PAGE_SHIFT_MIN 12
+#define K_PAGE_SHIFT_MAX 14
+#define K_NUM_CLASSES_MAX 77
+static size_t kPageShift  = 0;
+static size_t kNumClasses = 0;
+static size_t kPageSize   = 0;
+static Length kMaxValidPages = 0;
 static const size_t kMaxSize    = 32u * 1024;
 static const size_t kAlignShift = 3;
 static const size_t kAlignment  = 1 << kAlignShift;
-static const size_t kNumClasses = K_NUM_CLASSES;
-
+    
 // Allocates a big block of memory for the pagemap once we reach more than
 // 128MB
 static const size_t kPageMapBigAllocationThreshold = 128 << 20;
@@ -658,14 +676,14 @@ static const size_t kPageMapBigAllocationThreshold = 128 << 20;
 // should keep this value big because various incarnations of Linux
 // have small limits on the number of mmap() regions per
 // address-space.
-static const size_t kMinSystemAlloc = 1 << (20 - kPageShift);
+static const size_t kMinSystemAlloc = 1 << (20 - K_PAGE_SHIFT_MAX);
 
 // Number of objects to move between a per-thread list and a central
 // list in one shot.  We want this to be not too small so we can
 // amortize the lock overhead for accessing the central list.  Making
 // it too big may temporarily cause unnecessary memory wastage in the
 // per-thread free list until the scavenger cleans up the list.
-static int num_objects_to_move[kNumClasses];
+static int num_objects_to_move[K_NUM_CLASSES_MAX];
 
 // Maximum length we allow a per-thread free-list to have before we
 // move objects from it into the corresponding central free-list.  We
@@ -761,10 +779,10 @@ static inline int ClassIndex(size_t s) {
 }
 
 // Mapping from size class to max size storable in that class
-static size_t class_to_size[kNumClasses];
+static size_t class_to_size[K_NUM_CLASSES_MAX];
 
 // Mapping from size class to number of pages to allocate at a time
-static size_t class_to_pages[kNumClasses];
+static size_t class_to_pages[K_NUM_CLASSES_MAX];
 
 // Hardened singly linked list.  We make this a class to allow compiler to
 // statically prevent mismatching hardened and non-hardened list
@@ -809,8 +827,8 @@ struct TCEntry {
 // number of TCEntries across size classes is fixed.  Currently each size
 // class is initially given one TCEntry which also means that the maximum any
 // one class can have is kNumClasses.
-static const int kNumTransferEntries = kNumClasses;
-
+#define K_NUM_TRANSFER_ENTRIES_MAX static_cast<int>(K_NUM_CLASSES_MAX)
+#define kNumTransferEntries static_cast<int>(kNumClasses)
 // Note: the following only works for "n"s that fit in 32-bits, but
 // that is fine since we only use it for small sizes.
 static inline int LgFloor(size_t n) {
@@ -913,7 +931,25 @@ static int NumMoveSize(size_t size) {
 
 // Initialize the mapping arrays
 static void InitSizeClasses() {
-  // Do some sanity checking on add_amount[]/shift_amount[]/class_array[]
+#if OS(DARWIN)
+    kPageShift = vm_page_shift;
+    switch (kPageShift) {
+        case 12:
+            kNumClasses = 68;
+            break;
+        case 14:
+            kNumClasses = 77;
+            break;
+        default:
+            CRASH();
+    };
+#else
+    kPageShift = 12;
+    kNumClasses = 68;
+#endif
+    kPageSize = 1 << kPageShift;
+    kMaxValidPages = (~static_cast<Length>(0)) >> kPageShift;
+    // Do some sanity checking on add_amount[]/shift_amount[]/class_array[]
   if (ClassIndex(0) < 0) {
     MESSAGE("Invalid class index %d for size 0\n", ClassIndex(0));
     CRASH();
@@ -1139,11 +1175,6 @@ class PageHeapAllocator {
 
 // Type that can hold a page number
 typedef uintptr_t PageID;
-
-// Type that can hold the length of a run of pages
-typedef uintptr_t Length;
-
-static const Length kMaxValidPages = (~static_cast<Length>(0)) >> kPageShift;
 
 // Convert byte size into pages.  This won't overflow, but may return
 // an unreasonably large value if bytes is huge enough.
@@ -1427,7 +1458,7 @@ class TCMalloc_Central_FreeList {
   // Here we reserve space for TCEntry cache slots.  Since one size class can
   // end up getting all the TCEntries quota in the system we just preallocate
   // sufficient number of entries here.
-  TCEntry tc_slots_[kNumTransferEntries];
+  TCEntry tc_slots_[K_NUM_TRANSFER_ENTRIES_MAX];
 
   // Number of currently used cached entries in tc_slots_.  This variable is
   // updated under a lock but can be read without one.
@@ -1673,7 +1704,7 @@ static const size_t kBitsUnusedOn64Bit = 0;
 // A three-level map for 64-bit machines
 template <> class MapSelector<64> {
  public:
-  typedef TCMalloc_PageMap3<64 - kPageShift - kBitsUnusedOn64Bit> Type;
+  typedef TCMalloc_PageMap3<64 - K_PAGE_SHIFT_MIN - kBitsUnusedOn64Bit> Type;
   typedef PackedCache<64, uint64_t> CacheType;
 };
 #endif
@@ -1681,8 +1712,8 @@ template <> class MapSelector<64> {
 // A two-level map for 32-bit machines
 template <> class MapSelector<32> {
  public:
-  typedef TCMalloc_PageMap2<32 - kPageShift> Type;
-  typedef PackedCache<32 - kPageShift, uint16_t> CacheType;
+  typedef TCMalloc_PageMap2<32 - K_PAGE_SHIFT_MIN> Type;
+  typedef PackedCache<32 - K_PAGE_SHIFT_MIN, uint16_t> CacheType;
 };
 
 // -------------------------------------------------------------------------
@@ -1928,7 +1959,7 @@ void TCMalloc_PageHeap::init()
   scavenge_counter_ = 0;
   // Start scavenging at kMaxPages list
   scavenge_index_ = kMaxPages-1;
-  COMPILE_ASSERT(kNumClasses <= (1 << PageMapCache::kValuebits), valuebits);
+  ASSERT(kNumClasses <= (1 << PageMapCache::kValuebits));
   DLL_Init(&large_.normal, entropy_);
   DLL_Init(&large_.returned, entropy_);
   for (size_t i = 0; i < kMaxPages; i++) {
@@ -2740,7 +2771,7 @@ class TCMalloc_ThreadCache {
   size_t        size_;                  // Combined size of data
   ThreadIdentifier tid_;                // Which thread owns it
   bool          in_setspecific_;           // Called pthread_setspecific?
-  FreeList      list_[kNumClasses];     // Array indexed by size-class
+  FreeList      list_[K_NUM_CLASSES_MAX];     // Array indexed by size-class
 
   // We sample allocations, biased by the size of the allocation
   uint32_t      rnd_;                   // Cheap random number generator
@@ -2808,7 +2839,7 @@ class TCMalloc_ThreadCache {
 
 // Central cache -- a collection of free-lists, one per size-class.
 // We have a separate lock per free-list to reduce contention.
-static TCMalloc_Central_FreeListPadded central_cache[kNumClasses];
+static TCMalloc_Central_FreeListPadded central_cache[K_NUM_CLASSES_MAX];
 
 // Page-level allocator
 static AllocAlignmentInteger pageheap_memory[(sizeof(TCMalloc_PageHeap) + sizeof(AllocAlignmentInteger) - 1) / sizeof(AllocAlignmentInteger)];

--- a/buildItAll.sh
+++ b/buildItAll.sh
@@ -1,44 +1,50 @@
 #!/bin/sh
+
+CONFIG="Release"
+
+if (( $# > 0 )); then
+    CONFIG=$1
+fi
 rm -rf build
 mkdir build
 mkdir build/TiCore
 
 for arch in i386 x86_64; do
 	echo "Cleaning WTF"
-	xcodebuild -project WTF/WTF.xcodeproj -sdk iphonesimulator -configuration "Release" -target WTF clean > build/$arch.txt
+	xcodebuild -project WTF/WTF.xcodeproj -sdk iphonesimulator -configuration ${CONFIG} -target WTF clean > build/$arch.txt
 	rm -rf WTF/build
 	echo "Building WTF for $arch"
-	xcodebuild -project WTF/WTF.xcodeproj -sdk iphonesimulator -configuration "Release" -target WTF -arch $arch >> build/$arch.txt
+	xcodebuild -project WTF/WTF.xcodeproj -sdk iphonesimulator -configuration ${CONFIG} -target WTF -arch $arch >> build/$arch.txt
 	echo "Copying libWTF.a"
-	cp WTF/build/Release-iphonesimulator/libWTF.a build/libWTF.a
+	cp WTF/build/${CONFIG}-iphonesimulator/libWTF.a build/libWTF.a
 	echo "Cleaning JavaScriptCore"
-	xcodebuild -project JavaScriptCore/JavaScriptCore.xcodeproj -sdk iphonesimulator -configuration "Release" -target JavaScriptCore clean >> build/$arch.txt
+	xcodebuild -project JavaScriptCore/JavaScriptCore.xcodeproj -sdk iphonesimulator -configuration ${CONFIG} -target JavaScriptCore clean >> build/$arch.txt
 	rm -rf JavaScriptCore/build	
 	echo "Building JavaScriptCore for $arch"
-	xcodebuild -project JavaScriptCore/JavaScriptCore.xcodeproj -sdk iphonesimulator -configuration "Release" -target JavaScriptCore -arch $arch >> build/$arch.txt
+	xcodebuild -project JavaScriptCore/JavaScriptCore.xcodeproj -sdk iphonesimulator -configuration ${CONFIG} -target JavaScriptCore -arch $arch >> build/$arch.txt
 	mkdir build/TiCore/$arch
 	echo "Copying libJavaScriptCore.a"
-	cp JavaScriptCore/build/Release-iphonesimulator/libJavaScriptCore.a build/TiCore/$arch/
+	cp JavaScriptCore/build/${CONFIG}-iphonesimulator/libJavaScriptCore.a build/TiCore/$arch/
 	rm build/libWTF.a
 done
 
 
 for arch in armv7 arm64; do
 	echo "Cleaning WTF"
-	xcodebuild -project WTF/WTF.xcodeproj -sdk iphoneos -configuration "Release" -target WTF clean > build/$arch.txt
+	xcodebuild -project WTF/WTF.xcodeproj -sdk iphoneos -configuration ${CONFIG} -target WTF clean > build/$arch.txt
 	rm -rf WTF/build
 	echo "Building WTF for $arch"
-	xcodebuild -project WTF/WTF.xcodeproj -sdk iphoneos -configuration "Release" -target WTF -arch $arch >> build/$arch.txt
+	xcodebuild -project WTF/WTF.xcodeproj -sdk iphoneos -configuration ${CONFIG} -target WTF -arch $arch >> build/$arch.txt
 	echo "Copying libWTF.a"
-	cp WTF/build/Release-iphoneos/libWTF.a build/libWTF.a
+	cp WTF/build/${CONFIG}-iphoneos/libWTF.a build/libWTF.a
 	echo "Cleaning JavaScriptCore"
-	xcodebuild -project JavaScriptCore/JavaScriptCore.xcodeproj -sdk iphoneos -configuration "Release" -target JavaScriptCore clean >> build/$arch.txt
+	xcodebuild -project JavaScriptCore/JavaScriptCore.xcodeproj -sdk iphoneos -configuration ${CONFIG} -target JavaScriptCore clean >> build/$arch.txt
 	rm -rf JavaScriptCore/build	
 	echo "Building JavaScriptCore for $arch"
-	xcodebuild -project JavaScriptCore/JavaScriptCore.xcodeproj -sdk iphoneos -configuration "Release" -target JavaScriptCore -arch $arch >> build/$arch.txt
+	xcodebuild -project JavaScriptCore/JavaScriptCore.xcodeproj -sdk iphoneos -configuration ${CONFIG} -target JavaScriptCore -arch $arch >> build/$arch.txt
 	mkdir build/TiCore/$arch
 	echo "Copying libJavaScriptCore.a"
-	cp JavaScriptCore/build/Release-iphoneos/libJavaScriptCore.a build/TiCore/$arch/
+	cp JavaScriptCore/build/${CONFIG}-iphoneos/libJavaScriptCore.a build/TiCore/$arch/
 	rm build/libWTF.a
 done
 
@@ -60,10 +66,10 @@ xcrun -sdk iphoneos lipo -info build/libTiCore.a
 echo "Copying Headers"
 
 mkdir build/PRIVATE_HEADERS
-cp -R WTF/build/Release-iphoneos/usr/local/include/ build/PRIVATE_HEADERS
+cp -R WTF/build/${CONFIG}-iphoneos/usr/local/include/ build/PRIVATE_HEADERS
 mkdir build/PUBLIC_HEADERS
 mkdir build/PUBLIC_HEADERS/JavaScriptCore
-cp -R JavaScriptCore/build/Release-iphoneos/usr/local/include/ build/PUBLIC_HEADERS/JavaScriptCore
-cp -R JavaScriptCore/build/Release-iphoneos/PRIVATE_HEADERS/ build/PRIVATE_HEADERS
+cp -R JavaScriptCore/build/${CONFIG}-iphoneos/usr/local/include/ build/PUBLIC_HEADERS/JavaScriptCore
+cp -R JavaScriptCore/build/${CONFIG}-iphoneos/PRIVATE_HEADERS/ build/PRIVATE_HEADERS
 
 echo "Done"


### PR DESCRIPTION
1. Pulls in patch set 168197 into tijscore which stops the 4byte alignment warnings shown when building for arm64.
2. Updated FastMalloc to use vm_page_shift instead of a constant PAGE_SHIFT 
3. Changed build script to allow debug builds from command line

Fixes [TIMOB-18249](https://jira.appcelerator.org/browse/TIMOB-18249)
